### PR TITLE
chore: cleanup hygiene + repair csv module behind feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,19 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
+          args: --all-features
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features
 
       - name: Clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-features --all-targets -- -D warnings
 
       - name: Format
         uses: actions-rs/cargo@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+# Local PR tooling artifacts
+/pr_extractor.sh
+/pr_info/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +69,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
@@ -67,6 +103,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nalgebra"
@@ -231,11 +273,20 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 name = "rsta"
 version = "0.0.1"
 dependencies = [
+ "chrono",
+ "csv",
  "ndarray",
  "num-traits",
+ "serde",
  "statrs",
  "thiserror",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -244,6 +295,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,17 @@ description = "Rust Statistical Technical Analysis (RSTA) - A library for financ
 license = "GPL-3.0"
 
 
+[features]
+default = []
+csv = ["dep:csv", "dep:serde", "dep:chrono"]
+
 [dependencies]
 ndarray = "0.15"
 thiserror = "1.0"
 num-traits = "0.2"
 statrs = "0.16"
+
+# Optional dependencies (enabled by feature flags)
+csv = { version = "1.3", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }

--- a/docs/roadmap/014-implement-candle-indicators.md
+++ b/docs/roadmap/014-implement-candle-indicators.md
@@ -1,0 +1,40 @@
+# Implement Indicator<Candle, T> for Each Indicator
+
+## Description
+Extend existing indicators to support working directly with Candle data, rather than just numerical (`f64`) values. This implementation will allow indicators to be calculated directly from candlestick data without preprocessing.
+
+## Value
+- Simplifies use of indicators with standard OHLCV datasets
+- Enhances flexibility by allowing indicators to use different price components (open, high, low, close)
+- Provides a more consistent API across all indicators
+- Reduces code duplication in client applications by eliminating the need to extract price data
+
+## Implementation Approach
+1. **Target Indicators**: Implement `Indicator<Candle, T>` trait for the following indicators:
+   - SimpleMovingAverage
+   - ExponentialMovingAverage
+   - STD (Standard Deviation)
+   - Add more indicators incrementally as needed
+
+2. **Implementation Details**:
+   - Enable indicators to work directly with Candle input data
+   - Use the `PriceDataAccessor` trait to access price components (open, high, low, close, volume)
+   - Default to using the close price when appropriate
+   - Add configuration options to allow users to specify which price component to use (close, open, high, low)
+   - Ensure dual support for both `f64` and `Candle` input types
+
+3. **Consistency**: Maintain consistency with existing indicators that already support Candle input (such as OnBalanceVolume, ChaikinMoneyFlow, and AccumulationDistributionLine)
+
+4. **Documentation**:
+   - Update documentation for all modified indicators
+   - Add clear examples demonstrating how to use indicators with Candle data
+   - Document configuration options for selecting price components
+
+5. **Testing**:
+   - Add comprehensive unit tests for the new Candle-based implementations
+   - Cover edge cases and verify calculation accuracy
+   - Compare results with existing f64-based calculations to ensure consistency
+
+## Category
+Technical Indicators
+

--- a/src/csv/mod.rs
+++ b/src/csv/mod.rs
@@ -1,0 +1,450 @@
+//! # CSV Module for Technical Analysis
+//!
+//! This module provides tools for loading OHLCV price data from CSV files,
+//! computing technical indicators in batch, and exporting the augmented
+//! dataset back to CSV.
+//!
+//! It is gated behind the `csv` feature flag and pulls in `csv`, `serde` and
+//! `chrono` as optional dependencies.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use rsta::csv::CsvFormatter;
+//! use rsta::indicators::trend::SimpleMovingAverage;
+//! use rsta::indicators::momentum::RelativeStrengthIndex;
+//!
+//! let mut formatter = CsvFormatter::new();
+//! formatter.load_from_file("price_data.csv").unwrap();
+//!
+//! formatter
+//!     .add_close_indicator("SMA20", Box::new(SimpleMovingAverage::new(20).unwrap()))
+//!     .add_close_indicator("RSI14", Box::new(RelativeStrengthIndex::new(14).unwrap()));
+//!
+//! formatter.calculate_and_export("enhanced_data.csv").unwrap();
+//! ```
+//!
+//! ## Scope
+//!
+//! Only scalar-valued indicators are supported in this module:
+//!
+//! - close-price indicators (`Indicator<f64, f64>`) — SMA, EMA, RSI, StdDev …
+//! - candle-based indicators (`Indicator<Candle, f64>`) — ATR, OBV, ADL, VROC,
+//!   CMF, Williams %R …
+//!
+//! Multi-output indicators (Bollinger Bands, Keltner Channels, Stochastic) will
+//! be supported in a follow-up: each output channel will be exposed as its own
+//! column.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use chrono::NaiveDate;
+use csv::{ReaderBuilder, WriterBuilder};
+use serde::{Deserialize, Serialize};
+
+use crate::indicators::{Candle, Indicator, IndicatorError};
+
+/// Configuration for CSV import/export operations.
+#[derive(Debug, Clone)]
+pub struct CsvConfig {
+    /// Date format for parsing dates from the input CSV (e.g. `"%Y-%m-%d"`).
+    pub date_format: String,
+    /// Whether the input CSV has a header row.
+    pub has_header: bool,
+    /// Field delimiter (default `b','`).
+    pub delimiter: u8,
+    /// Column indices for OHLCV data (date, open, high, low, close, volume).
+    pub column_indices: OhlcvColumnIndices,
+}
+
+impl Default for CsvConfig {
+    fn default() -> Self {
+        Self {
+            date_format: "%Y-%m-%d".to_string(),
+            has_header: true,
+            delimiter: b',',
+            column_indices: OhlcvColumnIndices::default(),
+        }
+    }
+}
+
+/// Column indices for OHLCV data in CSV files.
+#[derive(Debug, Clone, Copy)]
+pub struct OhlcvColumnIndices {
+    /// Index of the date column.
+    pub date: usize,
+    /// Index of the open price column.
+    pub open: usize,
+    /// Index of the high price column.
+    pub high: usize,
+    /// Index of the low price column.
+    pub low: usize,
+    /// Index of the close price column.
+    pub close: usize,
+    /// Index of the volume column.
+    pub volume: usize,
+}
+
+impl Default for OhlcvColumnIndices {
+    fn default() -> Self {
+        Self {
+            date: 0,
+            open: 1,
+            high: 2,
+            low: 3,
+            close: 4,
+            volume: 5,
+        }
+    }
+}
+
+/// A single row of OHLCV data, keeping the original date string alongside the
+/// parsed timestamp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OhlcvData {
+    /// Original date string from the CSV (preserved for round-tripping).
+    pub date: String,
+    /// Unix timestamp (seconds since epoch) parsed from `date`.
+    pub timestamp: u64,
+    /// Opening price.
+    pub open: f64,
+    /// Highest price during the period.
+    pub high: f64,
+    /// Lowest price during the period.
+    pub low: f64,
+    /// Closing price.
+    pub close: f64,
+    /// Trading volume.
+    pub volume: f64,
+}
+
+impl OhlcvData {
+    /// Build a [`Candle`] from this row (used as input for indicators).
+    pub fn to_candle(&self) -> Candle {
+        Candle {
+            timestamp: self.timestamp,
+            open: self.open,
+            high: self.high,
+            low: self.low,
+            close: self.close,
+            volume: self.volume,
+        }
+    }
+}
+
+/// Errors emitted by the CSV module.
+#[derive(Debug, thiserror::Error)]
+pub enum CsvError {
+    /// Underlying I/O error.
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Error from the underlying `csv` crate.
+    #[error("CSV error: {0}")]
+    Csv(#[from] csv::Error),
+
+    /// Error parsing a field (price, volume, date, …).
+    #[error("Parse error: {0}")]
+    Parse(String),
+
+    /// Indicator-level error during calculation.
+    #[error("Indicator error: {0}")]
+    Indicator(#[from] IndicatorError),
+
+    /// Triggered when calculation is requested without any loaded data.
+    #[error("Missing data for indicator calculation")]
+    MissingData,
+}
+
+/// Indicator that consumes close prices and produces a scalar value per period.
+type CloseIndicator = Box<dyn Indicator<f64, f64> + Send>;
+/// Indicator that consumes [`Candle`] data and produces a scalar value per period.
+type CandleIndicator = Box<dyn Indicator<Candle, f64> + Send>;
+
+/// Loads OHLCV data, runs registered indicators against it and exports the
+/// augmented dataset back to CSV.
+///
+/// `BTreeMap` is used internally to keep indicator columns in a deterministic
+/// (alphabetical) order in the exported CSV.
+pub struct CsvFormatter {
+    config: CsvConfig,
+    data: Vec<OhlcvData>,
+    close_indicators: BTreeMap<String, CloseIndicator>,
+    candle_indicators: BTreeMap<String, CandleIndicator>,
+    calculated_values: BTreeMap<String, Vec<Option<f64>>>,
+}
+
+impl Default for CsvFormatter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CsvFormatter {
+    /// Create a new formatter with default configuration.
+    pub fn new() -> Self {
+        Self::with_config(CsvConfig::default())
+    }
+
+    /// Create a new formatter with a custom configuration.
+    pub fn with_config(config: CsvConfig) -> Self {
+        Self {
+            config,
+            data: Vec::new(),
+            close_indicators: BTreeMap::new(),
+            candle_indicators: BTreeMap::new(),
+            calculated_values: BTreeMap::new(),
+        }
+    }
+
+    /// Load OHLCV data from a CSV file at `path`.
+    pub fn load_from_file<P: AsRef<Path>>(&mut self, path: P) -> Result<(), CsvError> {
+        let file = File::open(path)?;
+        self.load_from_reader(file)
+    }
+
+    /// Load OHLCV data from any reader.
+    pub fn load_from_reader<R: Read>(&mut self, reader: R) -> Result<(), CsvError> {
+        let mut rdr = ReaderBuilder::new()
+            .has_headers(self.config.has_header)
+            .delimiter(self.config.delimiter)
+            .from_reader(reader);
+
+        self.data.clear();
+        self.calculated_values.clear();
+
+        let ci = self.config.column_indices;
+        for result in rdr.records() {
+            let record = result?;
+
+            if record.len() <= ci.volume {
+                return Err(CsvError::Parse(
+                    "Record has fewer columns than expected".to_string(),
+                ));
+            }
+
+            let date = record.get(ci.date).unwrap_or("").to_string();
+            let timestamp = parse_timestamp(&date, &self.config.date_format)?;
+            let open = parse_f64(record.get(ci.open), "open")?;
+            let high = parse_f64(record.get(ci.high), "high")?;
+            let low = parse_f64(record.get(ci.low), "low")?;
+            let close = parse_f64(record.get(ci.close), "close")?;
+            let volume = parse_f64(record.get(ci.volume), "volume")?;
+
+            self.data.push(OhlcvData {
+                date,
+                timestamp,
+                open,
+                high,
+                low,
+                close,
+                volume,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Register an indicator that consumes close prices and outputs a scalar.
+    ///
+    /// Returns `&mut self` to allow chaining.
+    pub fn add_close_indicator(&mut self, name: &str, indicator: CloseIndicator) -> &mut Self {
+        self.close_indicators.insert(name.to_string(), indicator);
+        self
+    }
+
+    /// Register an indicator that consumes [`Candle`] data and outputs a scalar.
+    ///
+    /// Returns `&mut self` to allow chaining.
+    pub fn add_candle_indicator(&mut self, name: &str, indicator: CandleIndicator) -> &mut Self {
+        self.candle_indicators.insert(name.to_string(), indicator);
+        self
+    }
+
+    /// Calculate every registered indicator on the loaded data.
+    pub fn calculate_indicators(&mut self) -> Result<(), CsvError> {
+        if self.data.is_empty() {
+            return Err(CsvError::MissingData);
+        }
+
+        let len = self.data.len();
+        let candles: Vec<Candle> = self.data.iter().map(OhlcvData::to_candle).collect();
+        let closes: Vec<f64> = candles.iter().map(|c| c.close).collect();
+
+        for (name, indicator) in self.close_indicators.iter_mut() {
+            let values = indicator.calculate(&closes)?;
+            self.calculated_values
+                .insert(name.clone(), align_to_len(values, len));
+        }
+
+        for (name, indicator) in self.candle_indicators.iter_mut() {
+            let values = indicator.calculate(&candles)?;
+            self.calculated_values
+                .insert(name.clone(), align_to_len(values, len));
+        }
+
+        Ok(())
+    }
+
+    /// Calculate indicators and export the augmented data to `path`.
+    pub fn calculate_and_export<P: AsRef<Path>>(&mut self, path: P) -> Result<(), CsvError> {
+        self.calculate_indicators()?;
+        self.export_to_file(path)
+    }
+
+    /// Export the augmented data (raw OHLCV + indicator columns) to `path`.
+    pub fn export_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), CsvError> {
+        let file = File::create(path)?;
+        self.export_to_writer(file)
+    }
+
+    /// Export the augmented data to any writer.
+    pub fn export_to_writer<W: Write>(&self, writer: W) -> Result<(), CsvError> {
+        let mut wtr = WriterBuilder::new()
+            .delimiter(self.config.delimiter)
+            .from_writer(writer);
+
+        let mut header = vec![
+            "Date".to_string(),
+            "Open".to_string(),
+            "High".to_string(),
+            "Low".to_string(),
+            "Close".to_string(),
+            "Volume".to_string(),
+        ];
+        for name in self.calculated_values.keys() {
+            header.push(name.clone());
+        }
+        wtr.write_record(&header)?;
+
+        for (i, data) in self.data.iter().enumerate() {
+            let mut row = vec![
+                data.date.clone(),
+                data.open.to_string(),
+                data.high.to_string(),
+                data.low.to_string(),
+                data.close.to_string(),
+                data.volume.to_string(),
+            ];
+            for values in self.calculated_values.values() {
+                row.push(match values.get(i).copied().flatten() {
+                    Some(v) => v.to_string(),
+                    None => String::new(),
+                });
+            }
+            wtr.write_record(&row)?;
+        }
+
+        wtr.flush()?;
+        Ok(())
+    }
+
+    /// Borrow the loaded OHLCV data.
+    pub fn data(&self) -> &[OhlcvData] {
+        &self.data
+    }
+
+    /// Borrow the calculated values for the indicator registered as `name`.
+    pub fn indicator_values(&self, name: &str) -> Option<&Vec<Option<f64>>> {
+        self.calculated_values.get(name)
+    }
+}
+
+fn parse_f64(value: Option<&str>, field: &str) -> Result<f64, CsvError> {
+    value
+        .unwrap_or("0")
+        .parse::<f64>()
+        .map_err(|e| CsvError::Parse(format!("Failed to parse {field}: {e}")))
+}
+
+fn parse_timestamp(date: &str, format: &str) -> Result<u64, CsvError> {
+    if date.is_empty() {
+        return Ok(0);
+    }
+    let parsed = NaiveDate::parse_from_str(date, format)
+        .map_err(|e| CsvError::Parse(format!("Failed to parse date '{date}': {e}")))?;
+    let dt = parsed
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| CsvError::Parse(format!("Invalid date '{date}'")))?;
+    Ok(dt.and_utc().timestamp() as u64)
+}
+
+/// Right-align indicator output with the source data: indicators that need a
+/// warmup period emit fewer values than the input length, so we left-pad with
+/// `None`.
+fn align_to_len(values: Vec<f64>, len: usize) -> Vec<Option<f64>> {
+    let pad = len.saturating_sub(values.len());
+    let mut out = Vec::with_capacity(len);
+    out.extend(std::iter::repeat_n(None, pad));
+    out.extend(values.into_iter().map(Some));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indicators::trend::SimpleMovingAverage;
+    use crate::indicators::volatility::AverageTrueRange;
+
+    fn sample_csv() -> &'static str {
+        "Date,Open,High,Low,Close,Volume\n\
+         2024-01-01,10,12,9,11,1000\n\
+         2024-01-02,11,13,10,12,1100\n\
+         2024-01-03,12,14,11,13,1200\n\
+         2024-01-04,13,15,12,14,1300\n\
+         2024-01-05,14,16,13,15,1400\n"
+    }
+
+    #[test]
+    fn loads_data_and_parses_timestamp() {
+        let mut f = CsvFormatter::new();
+        f.load_from_reader(sample_csv().as_bytes()).unwrap();
+        assert_eq!(f.data().len(), 5);
+        assert!(f.data()[0].timestamp > 0);
+        assert_eq!(f.data()[0].close, 11.0);
+    }
+
+    #[test]
+    fn calculates_close_and_candle_indicators() {
+        let mut f = CsvFormatter::new();
+        f.load_from_reader(sample_csv().as_bytes()).unwrap();
+        f.add_close_indicator("SMA3", Box::new(SimpleMovingAverage::new(3).unwrap()))
+            .add_candle_indicator("ATR3", Box::new(AverageTrueRange::new(3).unwrap()));
+        f.calculate_indicators().unwrap();
+
+        let sma = f.indicator_values("SMA3").unwrap();
+        assert_eq!(sma.len(), 5);
+        assert!(sma[0].is_none() && sma[1].is_none());
+        assert_eq!(sma[2], Some(12.0));
+        assert_eq!(sma[3], Some(13.0));
+        assert_eq!(sma[4], Some(14.0));
+
+        let atr = f.indicator_values("ATR3").unwrap();
+        assert_eq!(atr.len(), 5);
+        assert!(atr.last().unwrap().is_some());
+    }
+
+    #[test]
+    fn calculate_without_data_errors() {
+        let mut f = CsvFormatter::new();
+        let err = f.calculate_indicators().unwrap_err();
+        assert!(matches!(err, CsvError::MissingData));
+    }
+
+    #[test]
+    fn round_trips_through_export() {
+        let mut f = CsvFormatter::new();
+        f.load_from_reader(sample_csv().as_bytes()).unwrap();
+        f.add_close_indicator("SMA3", Box::new(SimpleMovingAverage::new(3).unwrap()));
+        f.calculate_indicators().unwrap();
+
+        let mut out = Vec::new();
+        f.export_to_writer(&mut out).unwrap();
+        let exported = String::from_utf8(out).unwrap();
+        assert!(exported.contains("SMA3"));
+        assert!(exported.contains("2024-01-03"));
+    }
+}

--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -111,10 +111,26 @@ pub use self::volatility::{
 
 // Re-export volume indicators
 pub use self::volume::{
-    AccumulationDistributionLine,
-    OnBalanceVolume,
-    VolumeRateOfChange, // ChaikinMoneyFlow is not public in volume.rs
+    AccumulationDistributionLine, ChaikinMoneyFlow, OnBalanceVolume, VolumeRateOfChange,
 };
+
+// Short-name aliases for ergonomic use (matching common TA terminology).
+/// Alias for [`SimpleMovingAverage`].
+pub type Sma = SimpleMovingAverage;
+/// Alias for [`ExponentialMovingAverage`].
+pub type Ema = ExponentialMovingAverage;
+/// Alias for [`RelativeStrengthIndex`].
+pub type Rsi = RelativeStrengthIndex;
+/// Alias for [`AverageTrueRange`].
+pub type Atr = AverageTrueRange;
+/// Alias for [`OnBalanceVolume`].
+pub type Obv = OnBalanceVolume;
+/// Alias for [`ChaikinMoneyFlow`].
+pub type Cmf = ChaikinMoneyFlow;
+/// Alias for [`VolumeRateOfChange`].
+pub type Vroc = VolumeRateOfChange;
+/// Alias for [`AccumulationDistributionLine`].
+pub type Adl = AccumulationDistributionLine;
 
 // Re-export utility functions
 pub use self::utils::{

--- a/src/indicators/traits.rs
+++ b/src/indicators/traits.rs
@@ -165,18 +165,22 @@ pub trait PriceDataAccessor<T> {
 }
 
 /// Default implementation for f64 price data
+///
+/// When the underlying data is a single price, all OHLC accessors return that
+/// price uniformly so generic indicators behave identically whether they are
+/// fed `f64` or `Candle` data. Volume defaults to `0.0`.
 impl PriceDataAccessor<f64> for f64 {
     fn get_close(&self, data: &f64) -> f64 {
         *data
     }
-    fn get_high(&self, _: &f64) -> f64 {
-        *self
+    fn get_high(&self, data: &f64) -> f64 {
+        *data
     }
-    fn get_low(&self, _: &f64) -> f64 {
-        *self
+    fn get_low(&self, data: &f64) -> f64 {
+        *data
     }
-    fn get_open(&self, _: &f64) -> f64 {
-        *self
+    fn get_open(&self, data: &f64) -> f64 {
+        *data
     }
     fn get_volume(&self, _: &f64) -> f64 {
         0.0

--- a/src/indicators/volume.rs
+++ b/src/indicators/volume.rs
@@ -1772,7 +1772,7 @@ mod tests {
         let mut vroc = VolumeRateOfChange::new(2).unwrap();
 
         // Create test candles
-        let candles = vec![
+        let candles = [
             Candle {
                 timestamp: 1,
                 open: 10.0,
@@ -2216,7 +2216,7 @@ mod tests {
         let mut cmf = ChaikinMoneyFlow::new(3).unwrap();
 
         // Create test candles
-        let candles = vec![
+        let candles = [
             Candle {
                 timestamp: 1,
                 open: 10.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,10 @@
 /// Re-exports all indicator modules
 pub mod indicators;
 
+/// CSV import/export utilities (gated behind the `csv` feature).
+#[cfg(feature = "csv")]
+pub mod csv;
+
 // Re-export key types for convenience
 pub use indicators::Candle;
 pub use indicators::Indicator;


### PR DESCRIPTION
## Summary

PR #1 du plan multi-vagues vers une lib TA state-of-the-art. **Cleanup uniquement** — aucun changement fonctionnel des indicateurs existants.

- **csv/ module** : ressuscité derrière le feature flag `csv` (deps `csv`, `serde`, `chrono` désormais optionnelles). Le code original ne compilait pas — il référençait un `name()` inexistant sur le trait, faisait un `HashMap<String, Box<dyn Indicator>>` impossible avec un trait générique, et était tronqué. Réécrit avec deux maps typées : `add_close_indicator` (`Indicator<f64, f64>`) et `add_candle_indicator` (`Indicator<Candle, f64>`). Multi-output (Bollinger, Keltner, Stoch) traité dans une PR ultérieure.
- **Timestamp** : `OhlcvData::to_candle()` parse maintenant la date via `chrono::NaiveDate` au lieu de la perdre.
- **PriceDataAccessor<f64>** : `get_high/low/open` retournaient `*self` au lieu de `*data` (incohérence cosmétique avec `get_close`). Unifié.
- **ChaikinMoneyFlow** : ré-exporté (le commentaire « not public in volume.rs » était faux).
- **Aliases courts** : `Sma`, `Ema`, `Rsi`, `Atr`, `Obv`, `Cmf`, `Vroc`, `Adl` — terminologie usuelle TA.
- **Hygiène git** : `pr_extractor.sh` et `pr_info/` ignorés ; `todo/` déplacé dans `docs/roadmap/` (tracké).
- **CI** : `build`, `test`, `clippy` désormais lancés avec `--all-features` pour exercer le module csv.

## Test plan

- [x] `cargo test` (sans features) → 99 tests + 22 doctests
- [x] `cargo test --all-features` → 103 tests + 23 doctests (4 nouveaux tests pour csv)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI verte sur ubuntu/windows/macOS × stable/beta/nightly

## Suite

Voir le plan complet : foundation `T: Float` + TODO #014 (PR #2), puis MACD/ADX/CCI/MFI/Donchian/Parabolic SAR/VWAP/MA-variants/Ichimoku/Heikin-Ashi/Pivots (PRs #3–#14), puis signaux (#15) et backtesting (#16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)