### PR TITLE
feat(trend): implement MACD indicator

### DIFF
--- a/scripts/gen_golden.py
+++ b/scripts/gen_golden.py
@@ -50,6 +50,12 @@ def main() -> None:
     write_golden("sma_5", ta.sma(df["close"], length=5))
     write_golden("ema_5", ta.ema(df["close"], length=5))
     write_golden("rsi_14", ta.rsi(df["close"], length=14))
+
+    # MACD has three output series; persist each as its own golden CSV.
+    macd = ta.macd(df["close"], fast=12, slow=26, signal=9)
+    write_golden("macd_12_26_9_line", macd["MACD_12_26_9"])
+    write_golden("macd_12_26_9_signal", macd["MACDs_12_26_9"])
+    write_golden("macd_12_26_9_hist", macd["MACDh_12_26_9"])
     # Add additional indicators as they land in the crate.
 
 

--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -96,7 +96,10 @@ pub use self::error::IndicatorError;
 pub use self::traits::{Indicator, PriceDataAccessor};
 
 // Re-export trend indicators
-pub use self::trend::{ExponentialMovingAverage, SimpleMovingAverage};
+pub use self::trend::{
+    ExponentialMovingAverage, MovingAverageConvergenceDivergence,
+    MovingAverageConvergenceDivergenceResult, SimpleMovingAverage,
+};
 
 // Re-export momentum indicators
 pub use self::momentum::{
@@ -131,6 +134,10 @@ pub type Cmf = ChaikinMoneyFlow;
 pub type Vroc = VolumeRateOfChange;
 /// Alias for [`AccumulationDistributionLine`].
 pub type Adl = AccumulationDistributionLine;
+/// Alias for [`MovingAverageConvergenceDivergence`].
+pub type Macd = MovingAverageConvergenceDivergence;
+/// Alias for [`MovingAverageConvergenceDivergenceResult`].
+pub type MacdResult = MovingAverageConvergenceDivergenceResult;
 
 // Re-export utility functions
 pub use self::utils::{

--- a/src/indicators/trend.rs
+++ b/src/indicators/trend.rs
@@ -2,7 +2,9 @@
 //!
 //! This module contains trend following indicators like Moving Averages, MACD, and Bollinger Bands.
 
-use crate::indicators::utils::{calculate_ema, calculate_sma, validate_period};
+use crate::indicators::utils::{
+    calculate_ema, calculate_sma, validate_data_length, validate_period,
+};
 use crate::indicators::{Candle, Indicator, IndicatorError};
 use std::collections::VecDeque;
 
@@ -199,6 +201,187 @@ impl ExponentialMovingAverage {
     }
 }
 
+/// MACD (Moving Average Convergence/Divergence) result.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MovingAverageConvergenceDivergenceResult {
+    /// MACD line: `EMA(fast) - EMA(slow)`.
+    pub macd: f64,
+    /// Signal line: EMA of the MACD line.
+    pub signal: f64,
+    /// Histogram: `macd - signal`. Positive = bullish momentum.
+    pub histogram: f64,
+}
+
+/// Moving Average Convergence/Divergence (MACD) indicator.
+///
+/// MACD is a trend-following momentum indicator that shows the relationship
+/// between two exponential moving averages of an asset's price. It is composed
+/// of three series:
+///
+/// - **MACD line** = EMA(fast_period) − EMA(slow_period)
+/// - **Signal line** = EMA(signal_period) of the MACD line
+/// - **Histogram** = MACD − signal
+///
+/// Standard parameters are 12/26/9.
+///
+/// # Example
+///
+/// ```no_run
+/// use rsta::indicators::trend::MovingAverageConvergenceDivergence;
+/// use rsta::indicators::Indicator;
+///
+/// let mut macd = MovingAverageConvergenceDivergence::new(12, 26, 9).unwrap();
+/// let prices: Vec<f64> = (1..=60).map(|i| i as f64).collect();
+/// let values = macd.calculate(&prices).unwrap();
+/// assert!(!values.is_empty());
+/// ```
+#[derive(Debug)]
+pub struct MovingAverageConvergenceDivergence {
+    fast_period: usize,
+    slow_period: usize,
+    signal_period: usize,
+    fast_ema: ExponentialMovingAverage,
+    slow_ema: ExponentialMovingAverage,
+    signal_ema: ExponentialMovingAverage,
+    /// Number of close prices observed so far via `next()`.
+    seen: usize,
+}
+
+impl MovingAverageConvergenceDivergence {
+    /// Create a new MACD indicator.
+    ///
+    /// # Errors
+    /// Returns `IndicatorError::InvalidParameter` if any period is `0` or if
+    /// `fast_period >= slow_period` (otherwise the MACD line collapses).
+    pub fn new(
+        fast_period: usize,
+        slow_period: usize,
+        signal_period: usize,
+    ) -> Result<Self, IndicatorError> {
+        validate_period(fast_period, 1)?;
+        validate_period(slow_period, 1)?;
+        validate_period(signal_period, 1)?;
+        if fast_period >= slow_period {
+            return Err(IndicatorError::InvalidParameter(
+                "fast_period must be strictly less than slow_period".to_string(),
+            ));
+        }
+        Ok(Self {
+            fast_period,
+            slow_period,
+            signal_period,
+            fast_ema: ExponentialMovingAverage::new(fast_period)?,
+            slow_ema: ExponentialMovingAverage::new(slow_period)?,
+            signal_ema: ExponentialMovingAverage::new(signal_period)?,
+            seen: 0,
+        })
+    }
+
+    /// Fast EMA period.
+    pub fn fast_period(&self) -> usize {
+        self.fast_period
+    }
+    /// Slow EMA period.
+    pub fn slow_period(&self) -> usize {
+        self.slow_period
+    }
+    /// Signal EMA period.
+    pub fn signal_period(&self) -> usize {
+        self.signal_period
+    }
+
+    /// Convenience: feed candles by extracting the close price.
+    pub fn calculate_candles(
+        &mut self,
+        candles: &[Candle],
+    ) -> Result<Vec<MovingAverageConvergenceDivergenceResult>, IndicatorError> {
+        let closes: Vec<f64> = candles.iter().map(|c| c.close).collect();
+        <Self as Indicator<f64, MovingAverageConvergenceDivergenceResult>>::calculate(self, &closes)
+    }
+
+    /// Convenience: streaming update with the close price of a candle.
+    pub fn next_candle(
+        &mut self,
+        candle: Candle,
+    ) -> Result<Option<MovingAverageConvergenceDivergenceResult>, IndicatorError> {
+        <Self as Indicator<f64, MovingAverageConvergenceDivergenceResult>>::next(self, candle.close)
+    }
+}
+
+impl Indicator<f64, MovingAverageConvergenceDivergenceResult>
+    for MovingAverageConvergenceDivergence
+{
+    fn calculate(
+        &mut self,
+        data: &[f64],
+    ) -> Result<Vec<MovingAverageConvergenceDivergenceResult>, IndicatorError> {
+        // We need at least slow_period prices for the MACD line, plus
+        // signal_period values of the MACD line for the signal line. The
+        // signal line seeds on its first value, so the very first MACD
+        // datapoint produces signal = macd and histogram = 0.
+        let needed = self.slow_period;
+        validate_data_length(data, needed)?;
+
+        self.reset();
+
+        let mut out = Vec::with_capacity(data.len().saturating_sub(needed - 1));
+        for &price in data {
+            if let Some(point) = self.next(price)? {
+                out.push(point);
+            }
+        }
+        Ok(out)
+    }
+
+    fn next(
+        &mut self,
+        value: f64,
+    ) -> Result<Option<MovingAverageConvergenceDivergenceResult>, IndicatorError> {
+        self.seen += 1;
+        let fast = self.fast_ema.next(value)?;
+        let slow = self.slow_ema.next(value)?;
+
+        // Emit nothing until both EMAs have stabilised over their full
+        // window, which by convention is `slow_period` close prices.
+        if self.seen < self.slow_period {
+            return Ok(None);
+        }
+
+        match (fast, slow) {
+            (Some(f), Some(s)) => {
+                let macd = f - s;
+                let signal = self
+                    .signal_ema
+                    .next(macd)?
+                    .expect("signal EMA always emits on first value");
+                Ok(Some(MovingAverageConvergenceDivergenceResult {
+                    macd,
+                    signal,
+                    histogram: macd - signal,
+                }))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.fast_ema.reset();
+        self.slow_ema.reset();
+        self.signal_ema.reset();
+        self.seen = 0;
+    }
+
+    fn name(&self) -> &'static str {
+        "MACD"
+    }
+
+    fn period(&self) -> Option<usize> {
+        // MACD has three periods; surfacing only the slow one would be
+        // misleading.
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -314,5 +497,56 @@ mod tests {
 
         // Should be back to initial state, next value becomes seed
         assert_eq!(ema.next(6.0).unwrap(), Some(6.0));
+    }
+
+    #[test]
+    fn test_macd_construction_validates_periods() {
+        // fast must be strictly less than slow
+        assert!(MovingAverageConvergenceDivergence::new(26, 26, 9).is_err());
+        assert!(MovingAverageConvergenceDivergence::new(30, 26, 9).is_err());
+        // any zero period is rejected
+        assert!(MovingAverageConvergenceDivergence::new(0, 26, 9).is_err());
+        assert!(MovingAverageConvergenceDivergence::new(12, 0, 9).is_err());
+        assert!(MovingAverageConvergenceDivergence::new(12, 26, 0).is_err());
+        // standard parameters work
+        assert!(MovingAverageConvergenceDivergence::new(12, 26, 9).is_ok());
+    }
+
+    #[test]
+    fn test_macd_emits_after_warmup() {
+        let mut macd = MovingAverageConvergenceDivergence::new(3, 6, 2).unwrap();
+        // Slow period is 6, so the first 5 closes produce no output.
+        for v in [1.0, 2.0, 3.0, 4.0, 5.0] {
+            assert!(macd.next(v).unwrap().is_none(), "premature emission");
+        }
+        let first = macd.next(6.0).unwrap().expect("should emit at slow_period");
+        // First emission: signal seeded with current MACD → histogram == 0.
+        assert!(first.histogram.abs() < 1e-12);
+        assert!((first.macd - first.signal).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_macd_calculate_matches_streaming() {
+        let prices: Vec<f64> = (1..=40).map(|i| i as f64).collect();
+        let mut batch = MovingAverageConvergenceDivergence::new(12, 26, 9).unwrap();
+        let batch_out = batch.calculate(&prices).unwrap();
+
+        let mut stream = MovingAverageConvergenceDivergence::new(12, 26, 9).unwrap();
+        let stream_out: Vec<_> = prices
+            .iter()
+            .filter_map(|&p| stream.next(p).unwrap())
+            .collect();
+
+        assert_eq!(batch_out, stream_out);
+    }
+
+    #[test]
+    fn test_macd_histogram_definition() {
+        let prices: Vec<f64> = (1..=40).map(|i| i as f64).collect();
+        let mut macd = MovingAverageConvergenceDivergence::new(12, 26, 9).unwrap();
+        let out = macd.calculate(&prices).unwrap();
+        for v in &out {
+            assert!((v.histogram - (v.macd - v.signal)).abs() < 1e-12);
+        }
     }
 }


### PR DESCRIPTION
## Summary

PR #3 — MACD. Stacked sur #10.

- `MovingAverageConvergenceDivergence` (alias `Macd`) avec paramètres standard 12/26/9.
- Composition de trois `ExponentialMovingAverage` (fast/slow/signal).
- Sortie `MovingAverageConvergenceDivergenceResult { macd, signal, histogram }` (alias `MacdResult`).
- Helpers `calculate_candles` / `next_candle`.
- Validation : `fast_period < slow_period`, périodes ≥ 1.
- Tests : construction, warmup, batch == streaming, identité `histogram = macd - signal`.
- `scripts/gen_golden.py` mis à jour pour émettre les 3 séries MACD lorsque pandas-ta sera lancé.

Comble la référence à `Macd` qui avait été retirée de `csv/mod.rs` en PR #1.

## Test plan

- [x] `cargo test --all-features` → 107 unit + 24 doctests + 3 golden, tous verts
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)