### PR TITLE
feat(momentum): implement Commodity Channel Index (CCI)

### DIFF
--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -104,7 +104,7 @@ pub use self::trend::{
 
 // Re-export momentum indicators
 pub use self::momentum::{
-    RelativeStrengthIndex, StochasticOscillator, StochasticResult, WilliamsR,
+    CommodityChannelIndex, RelativeStrengthIndex, StochasticOscillator, StochasticResult, WilliamsR,
 };
 
 // Re-export volatility indicators
@@ -143,6 +143,8 @@ pub type MacdResult = MovingAverageConvergenceDivergenceResult;
 pub type Adx = AverageDirectionalIndex;
 /// Alias for [`AverageDirectionalIndexResult`].
 pub type AdxResult = AverageDirectionalIndexResult;
+/// Alias for [`CommodityChannelIndex`].
+pub type Cci = CommodityChannelIndex;
 
 // Re-export utility functions
 pub use self::utils::{

--- a/src/indicators/momentum.rs
+++ b/src/indicators/momentum.rs
@@ -205,6 +205,102 @@ impl RelativeStrengthIndex {
     }
 }
 
+/// Commodity Channel Index (CCI) indicator.
+///
+/// CCI measures the deviation of the typical price from its moving average,
+/// scaled by the mean absolute deviation. It oscillates around 0; readings
+/// above +100 traditionally signal overbought conditions and below −100
+/// oversold.
+///
+/// `CCI = (TP - SMA(TP, n)) / (0.015 * MeanDeviation)`
+///
+/// where `TP = (high + low + close) / 3` and the constant `0.015` is Lambert's
+/// scaling factor that puts roughly 70-80% of values in [−100, 100].
+///
+/// # Example
+/// ```no_run
+/// use rsta::indicators::momentum::CommodityChannelIndex;
+/// use rsta::indicators::{Indicator, Candle};
+///
+/// let mut cci = CommodityChannelIndex::new(20).unwrap();
+/// let candles: Vec<Candle> = (0..40)
+///     .map(|i| Candle {
+///         timestamp: i, open: i as f64, high: i as f64 + 1.0,
+///         low: i as f64 - 1.0, close: i as f64, volume: 1000.0,
+///     })
+///     .collect();
+/// let values = cci.calculate(&candles).unwrap();
+/// assert!(!values.is_empty());
+/// ```
+#[derive(Debug)]
+pub struct CommodityChannelIndex {
+    period: usize,
+    /// Rolling buffer of typical prices.
+    tp_buffer: VecDeque<f64>,
+}
+
+impl CommodityChannelIndex {
+    /// Create a new CCI indicator. Typical period is 20.
+    pub fn new(period: usize) -> Result<Self, IndicatorError> {
+        validate_period(period, 1)?;
+        Ok(Self {
+            period,
+            tp_buffer: VecDeque::with_capacity(period),
+        })
+    }
+
+    fn typical_price(c: &Candle) -> f64 {
+        (c.high + c.low + c.close) / 3.0
+    }
+}
+
+impl Indicator<Candle, f64> for CommodityChannelIndex {
+    fn calculate(&mut self, data: &[Candle]) -> Result<Vec<f64>, IndicatorError> {
+        validate_data_length(data, self.period)?;
+        self.reset();
+        let mut out = Vec::with_capacity(data.len() - self.period + 1);
+        for c in data {
+            if let Some(v) = self.next(*c)? {
+                out.push(v);
+            }
+        }
+        Ok(out)
+    }
+
+    fn next(&mut self, value: Candle) -> Result<Option<f64>, IndicatorError> {
+        let tp = Self::typical_price(&value);
+        self.tp_buffer.push_back(tp);
+        if self.tp_buffer.len() > self.period {
+            self.tp_buffer.pop_front();
+        }
+        if self.tp_buffer.len() < self.period {
+            return Ok(None);
+        }
+
+        let n = self.period as f64;
+        let sma: f64 = self.tp_buffer.iter().sum::<f64>() / n;
+        let mean_dev: f64 = self.tp_buffer.iter().map(|x| (x - sma).abs()).sum::<f64>() / n;
+
+        if mean_dev == 0.0 {
+            // Flat market — CCI is undefined; emit 0 to keep the contract.
+            return Ok(Some(0.0));
+        }
+        Ok(Some((tp - sma) / (0.015 * mean_dev)))
+    }
+
+    fn reset(&mut self) {
+        self.tp_buffer.clear();
+    }
+
+    fn name(&self) -> &'static str {
+        "CCI"
+    }
+
+    fn period(&self) -> Option<usize> {
+        Some(self.period)
+    }
+}
+
 /// Stochastic Oscillator
 ///
 /// The Stochastic Oscillator is a momentum indicator that shows the location of the close
@@ -882,5 +978,61 @@ mod tests {
         // %R = ((15 - 7) / (15 - 5)) * -100 = -80.0
         let r_value = WilliamsR::calculate_r(&candles, 2, 3);
         assert!((r_value - (-80.0)).abs() < 0.01);
+    }
+
+    fn cci_candles(count: usize) -> Vec<Candle> {
+        (0..count)
+            .map(|i| {
+                let mid = (i as f64) * 0.5 + (i as f64 % 5.0);
+                Candle {
+                    timestamp: i as u64,
+                    open: mid,
+                    high: mid + 1.0,
+                    low: mid - 1.0,
+                    close: mid + 0.25,
+                    volume: 1000.0,
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_cci_construction_validates_period() {
+        assert!(CommodityChannelIndex::new(0).is_err());
+        assert!(CommodityChannelIndex::new(20).is_ok());
+    }
+
+    #[test]
+    fn test_cci_warmup_and_calculate_matches_streaming() {
+        let candles = cci_candles(40);
+        let mut batch = CommodityChannelIndex::new(20).unwrap();
+        let batch_out = batch.calculate(&candles).unwrap();
+        assert_eq!(batch_out.len(), candles.len() - 19);
+
+        let mut stream = CommodityChannelIndex::new(20).unwrap();
+        let stream_out: Vec<f64> = candles
+            .iter()
+            .filter_map(|c| stream.next(*c).unwrap())
+            .collect();
+        assert_eq!(batch_out, stream_out);
+    }
+
+    #[test]
+    fn test_cci_constant_input_is_zero() {
+        // Flat market → mean deviation = 0; we emit 0 by convention.
+        let mut cci = CommodityChannelIndex::new(5).unwrap();
+        let flat = vec![
+            Candle {
+                timestamp: 0,
+                open: 10.0,
+                high: 10.0,
+                low: 10.0,
+                close: 10.0,
+                volume: 1.0
+            };
+            10
+        ];
+        let out = cci.calculate(&flat).unwrap();
+        assert!(out.iter().all(|&v| v == 0.0));
     }
 }


### PR DESCRIPTION
## Summary

PR #5 — CCI. Stacked sur #12.

- `CommodityChannelIndex` (alias `Cci`).
- `Indicator<Candle, f64>` — formule canonique de Lambert avec constante 0.015.
- TP = (high + low + close) / 3, comparé à sa SMA et normalisé par la mean deviation.
- Convention sur marché plat (mean dev = 0) : émet 0 plutôt que NaN.

## Test plan

- [x] `cargo test --all-features` → 114 unit + 26 doctests + 3 golden
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)