### PR TITLE
feat(volume): implement Money Flow Index (MFI)

### DIFF
--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -115,7 +115,8 @@ pub use self::volatility::{
 
 // Re-export volume indicators
 pub use self::volume::{
-    AccumulationDistributionLine, ChaikinMoneyFlow, OnBalanceVolume, VolumeRateOfChange,
+    AccumulationDistributionLine, ChaikinMoneyFlow, MoneyFlowIndex, OnBalanceVolume,
+    VolumeRateOfChange,
 };
 
 // Short-name aliases for ergonomic use (matching common TA terminology).
@@ -145,6 +146,8 @@ pub type Adx = AverageDirectionalIndex;
 pub type AdxResult = AverageDirectionalIndexResult;
 /// Alias for [`CommodityChannelIndex`].
 pub type Cci = CommodityChannelIndex;
+/// Alias for [`MoneyFlowIndex`].
+pub type Mfi = MoneyFlowIndex;
 
 // Re-export utility functions
 pub use self::utils::{

--- a/src/indicators/volume.rs
+++ b/src/indicators/volume.rs
@@ -646,6 +646,128 @@ impl Indicator<Candle, f64> for ChaikinMoneyFlow {
     }
 }
 
+/// Money Flow Index (MFI) — volume-weighted RSI.
+///
+/// MFI uses both price and volume to gauge overbought/oversold conditions.
+/// Bounds are 0..=100; readings above 80 are commonly considered overbought
+/// and below 20 oversold.
+///
+/// Algorithm (Wilder's classic, period typically 14):
+/// 1. Typical Price `TP = (high + low + close) / 3`
+/// 2. Raw Money Flow `RMF = TP * volume`
+/// 3. For each new bar with `TP > prev_TP` add `RMF` to the *positive* bucket;
+///    if `TP < prev_TP` add it to the *negative* bucket.
+/// 4. Sum each bucket over the lookback period.
+/// 5. `MFI = 100 - (100 / (1 + positive_sum / negative_sum))`. If
+///    `negative_sum == 0`, MFI is `100` (saturated up).
+///
+/// # Example
+/// ```no_run
+/// use rsta::indicators::volume::MoneyFlowIndex;
+/// use rsta::indicators::{Indicator, Candle};
+///
+/// let mut mfi = MoneyFlowIndex::new(14).unwrap();
+/// let candles: Vec<Candle> = (0..30).map(|i| Candle {
+///     timestamp: i, open: i as f64, high: i as f64 + 1.0,
+///     low: i as f64 - 1.0, close: i as f64, volume: 1000.0 + i as f64,
+/// }).collect();
+/// let values = mfi.calculate(&candles).unwrap();
+/// assert!(!values.is_empty());
+/// ```
+#[derive(Debug)]
+pub struct MoneyFlowIndex {
+    period: usize,
+    /// (typical_price, signed_raw_money_flow). Sign: +1 up, -1 down, 0 unchanged.
+    flow_buffer: VecDeque<(f64, f64, i8)>,
+    prev_tp: Option<f64>,
+}
+
+impl MoneyFlowIndex {
+    /// Create a new MFI indicator. Standard period is 14.
+    pub fn new(period: usize) -> Result<Self, IndicatorError> {
+        validate_period(period, 1)?;
+        Ok(Self {
+            period,
+            flow_buffer: VecDeque::with_capacity(period),
+            prev_tp: None,
+        })
+    }
+}
+
+impl Indicator<Candle, f64> for MoneyFlowIndex {
+    fn calculate(&mut self, data: &[Candle]) -> Result<Vec<f64>, IndicatorError> {
+        // Need `period + 1` candles: the first establishes prev_tp, then
+        // `period` directional samples fill the buffer.
+        validate_data_length(data, self.period + 1)?;
+        self.reset();
+        let mut out = Vec::with_capacity(data.len() - self.period);
+        for c in data {
+            if let Some(v) = self.next(*c)? {
+                out.push(v);
+            }
+        }
+        Ok(out)
+    }
+
+    fn next(&mut self, value: Candle) -> Result<Option<f64>, IndicatorError> {
+        let tp = (value.high + value.low + value.close) / 3.0;
+        let rmf = tp * value.volume;
+        let Some(prev) = self.prev_tp else {
+            self.prev_tp = Some(tp);
+            return Ok(None);
+        };
+        let direction: i8 = if tp > prev {
+            1
+        } else if tp < prev {
+            -1
+        } else {
+            0
+        };
+        self.prev_tp = Some(tp);
+
+        self.flow_buffer.push_back((tp, rmf, direction));
+        if self.flow_buffer.len() > self.period {
+            self.flow_buffer.pop_front();
+        }
+        if self.flow_buffer.len() < self.period {
+            return Ok(None);
+        }
+
+        let mut positive = 0.0f64;
+        let mut negative = 0.0f64;
+        for &(_, rmf, dir) in &self.flow_buffer {
+            match dir {
+                1 => positive += rmf,
+                -1 => negative += rmf,
+                _ => {}
+            }
+        }
+        if negative == 0.0 {
+            // No down moves in the window → MFI saturated up (or undefined
+            // when also positive == 0; emit 50 in that pathological case).
+            if positive == 0.0 {
+                return Ok(Some(50.0));
+            }
+            return Ok(Some(100.0));
+        }
+        let ratio = positive / negative;
+        Ok(Some(100.0 - 100.0 / (1.0 + ratio)))
+    }
+
+    fn reset(&mut self) {
+        self.flow_buffer.clear();
+        self.prev_tp = None;
+    }
+
+    fn name(&self) -> &'static str {
+        "MFI"
+    }
+
+    fn period(&self) -> Option<usize> {
+        Some(self.period)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2417,5 +2539,46 @@ mod tests {
             "CMF with extreme volumes should still be between -1 and 1, got: {}",
             result[0]
         );
+    }
+
+    fn ramp_candles(count: usize, vol: f64) -> Vec<Candle> {
+        (0..count)
+            .map(|i| Candle {
+                timestamp: i as u64,
+                open: i as f64,
+                high: i as f64 + 1.0,
+                low: i as f64 - 1.0,
+                close: i as f64,
+                volume: vol,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_mfi_construction_validates_period() {
+        assert!(MoneyFlowIndex::new(0).is_err());
+        assert!(MoneyFlowIndex::new(14).is_ok());
+    }
+
+    #[test]
+    fn test_mfi_pure_uptrend_saturates_to_100() {
+        // No down moves at all in the window → MFI saturates at 100.
+        let mut mfi = MoneyFlowIndex::new(5).unwrap();
+        let out = mfi.calculate(&ramp_candles(20, 1000.0)).unwrap();
+        assert!(out.iter().all(|&v| v == 100.0), "values: {out:?}");
+    }
+
+    #[test]
+    fn test_mfi_calculate_matches_streaming() {
+        let candles = ramp_candles(30, 1500.0);
+        let mut batch = MoneyFlowIndex::new(14).unwrap();
+        let batch_out = batch.calculate(&candles).unwrap();
+
+        let mut stream = MoneyFlowIndex::new(14).unwrap();
+        let stream_out: Vec<f64> = candles
+            .iter()
+            .filter_map(|c| stream.next(*c).unwrap())
+            .collect();
+        assert_eq!(batch_out, stream_out);
     }
 } // Close the test module


### PR DESCRIPTION
## Summary

PR #6 — MFI. Stacked sur #13.

- `MoneyFlowIndex` (alias `Mfi`) — RSI pondéré volume.
- `Indicator<Candle, f64>`, période standard 14.
- Cas pathologiques explicités : marché purement haussier → 100, totalement plat → 50.

## Test plan

- [x] `cargo test --all-features` → 117 unit + 27 doctests + 3 golden
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)