### PR TITLE
feat(volatility): implement Donchian Channels

### DIFF
--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -109,8 +109,8 @@ pub use self::momentum::{
 
 // Re-export volatility indicators
 pub use self::volatility::{
-    AverageTrueRange, BollingerBands, BollingerBandsResult, KeltnerChannels, KeltnerChannelsResult,
-    StandardDeviation,
+    AverageTrueRange, BollingerBands, BollingerBandsResult, DonchianChannels,
+    DonchianChannelsResult, KeltnerChannels, KeltnerChannelsResult, StandardDeviation,
 };
 
 // Re-export volume indicators
@@ -148,6 +148,8 @@ pub type AdxResult = AverageDirectionalIndexResult;
 pub type Cci = CommodityChannelIndex;
 /// Alias for [`MoneyFlowIndex`].
 pub type Mfi = MoneyFlowIndex;
+/// Alias for [`DonchianChannels`].
+pub type Donchian = DonchianChannels;
 
 // Re-export utility functions
 pub use self::utils::{

--- a/src/indicators/volatility.rs
+++ b/src/indicators/volatility.rs
@@ -744,6 +744,108 @@ impl Indicator<Candle, KeltnerChannelsResult> for KeltnerChannels {
     }
 }
 
+/// Donchian Channels result: rolling max high, min low and their midpoint.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DonchianChannelsResult {
+    /// Highest high over the lookback period.
+    pub upper: f64,
+    /// Midpoint: `(upper + lower) / 2`.
+    pub middle: f64,
+    /// Lowest low over the lookback period.
+    pub lower: f64,
+}
+
+/// Donchian Channels indicator.
+///
+/// Tracks the highest high and lowest low over the last `period` candles.
+/// Widely used as a breakout filter (e.g. the original Turtle Trading rules
+/// use a 20-period Donchian breakout).
+///
+/// # Example
+/// ```no_run
+/// use rsta::indicators::volatility::DonchianChannels;
+/// use rsta::indicators::{Indicator, Candle};
+///
+/// let mut dc = DonchianChannels::new(20).unwrap();
+/// let candles: Vec<Candle> = (0..40).map(|i| Candle {
+///     timestamp: i, open: i as f64, high: i as f64 + 2.0,
+///     low: i as f64 - 1.0, close: i as f64 + 1.0, volume: 1000.0,
+/// }).collect();
+/// let bands = dc.calculate(&candles).unwrap();
+/// assert!(!bands.is_empty());
+/// ```
+#[derive(Debug)]
+pub struct DonchianChannels {
+    period: usize,
+    /// Rolling buffer of (high, low) pairs.
+    buffer: VecDeque<(f64, f64)>,
+}
+
+impl DonchianChannels {
+    /// Create a new Donchian Channels indicator. Typical period is 20.
+    pub fn new(period: usize) -> Result<Self, IndicatorError> {
+        validate_period(period, 1)?;
+        Ok(Self {
+            period,
+            buffer: VecDeque::with_capacity(period),
+        })
+    }
+}
+
+impl Indicator<Candle, DonchianChannelsResult> for DonchianChannels {
+    fn calculate(
+        &mut self,
+        data: &[Candle],
+    ) -> Result<Vec<DonchianChannelsResult>, IndicatorError> {
+        validate_data_length(data, self.period)?;
+        self.reset();
+        let mut out = Vec::with_capacity(data.len() - self.period + 1);
+        for c in data {
+            if let Some(v) = self.next(*c)? {
+                out.push(v);
+            }
+        }
+        Ok(out)
+    }
+
+    fn next(&mut self, value: Candle) -> Result<Option<DonchianChannelsResult>, IndicatorError> {
+        self.buffer.push_back((value.high, value.low));
+        if self.buffer.len() > self.period {
+            self.buffer.pop_front();
+        }
+        if self.buffer.len() < self.period {
+            return Ok(None);
+        }
+        let upper = self
+            .buffer
+            .iter()
+            .map(|&(h, _)| h)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let lower = self
+            .buffer
+            .iter()
+            .map(|&(_, l)| l)
+            .fold(f64::INFINITY, f64::min);
+        Ok(Some(DonchianChannelsResult {
+            upper,
+            middle: (upper + lower) / 2.0,
+            lower,
+        }))
+    }
+
+    fn reset(&mut self) {
+        self.buffer.clear();
+    }
+
+    fn name(&self) -> &'static str {
+        "DonchianChannels"
+    }
+
+    fn period(&self) -> Option<usize> {
+        Some(self.period)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1192,5 +1294,72 @@ mod tests {
         // After reset, we should have cleared state
         assert!(kc.current_ema.is_none());
         assert!(kc.current_atr.is_none());
+    }
+
+    fn donchian_candles() -> Vec<Candle> {
+        vec![
+            Candle {
+                timestamp: 0,
+                open: 10.0,
+                high: 12.0,
+                low: 8.0,
+                close: 11.0,
+                volume: 1.0,
+            },
+            Candle {
+                timestamp: 1,
+                open: 11.0,
+                high: 13.0,
+                low: 9.0,
+                close: 12.0,
+                volume: 1.0,
+            },
+            Candle {
+                timestamp: 2,
+                open: 12.0,
+                high: 15.0,
+                low: 10.0,
+                close: 13.0,
+                volume: 1.0,
+            },
+            Candle {
+                timestamp: 3,
+                open: 13.0,
+                high: 14.0,
+                low: 11.0,
+                close: 12.0,
+                volume: 1.0,
+            },
+            Candle {
+                timestamp: 4,
+                open: 12.0,
+                high: 16.0,
+                low: 11.0,
+                close: 15.0,
+                volume: 1.0,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_donchian_validates_period() {
+        assert!(DonchianChannels::new(0).is_err());
+        assert!(DonchianChannels::new(20).is_ok());
+    }
+
+    #[test]
+    fn test_donchian_returns_max_high_min_low() {
+        let mut dc = DonchianChannels::new(3).unwrap();
+        let out = dc.calculate(&donchian_candles()).unwrap();
+        // 5 candles, period 3 → 3 emissions.
+        assert_eq!(out.len(), 3);
+        // First emission covers candles 0..3: highs 12,13,15 → 15; lows 8,9,10 → 8.
+        assert_eq!(out[0].upper, 15.0);
+        assert_eq!(out[0].lower, 8.0);
+        assert_eq!(out[0].middle, 11.5);
+        // Last emission covers candles 2..5: highs 15,14,16 → 16; lows 10,11,11 → 10.
+        assert_eq!(out[2].upper, 16.0);
+        assert_eq!(out[2].lower, 10.0);
+        assert_eq!(out[2].middle, 13.0);
     }
 }


### PR DESCRIPTION
## Summary

PR #7 — Donchian Channels. Stacked sur #14.

- `DonchianChannels` (alias `Donchian`) avec `DonchianChannelsResult { upper, middle, lower }`.
- `Indicator<Candle, _>`, max(high) / min(low) sur la fenêtre.

## Test plan

- [x] 119 unit + 28 doctests + 3 golden, tous verts
- [x] clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)