### PR TITLE
feat(volume): implement VWAP

### DIFF
--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -116,7 +116,7 @@ pub use self::volatility::{
 // Re-export volume indicators
 pub use self::volume::{
     AccumulationDistributionLine, ChaikinMoneyFlow, MoneyFlowIndex, OnBalanceVolume,
-    VolumeRateOfChange,
+    VolumeRateOfChange, VolumeWeightedAveragePrice,
 };
 
 // Short-name aliases for ergonomic use (matching common TA terminology).
@@ -150,6 +150,8 @@ pub type Cci = CommodityChannelIndex;
 pub type Mfi = MoneyFlowIndex;
 /// Alias for [`DonchianChannels`].
 pub type Donchian = DonchianChannels;
+/// Alias for [`VolumeWeightedAveragePrice`].
+pub type Vwap = VolumeWeightedAveragePrice;
 
 // Re-export utility functions
 pub use self::utils::{

--- a/src/indicators/volume.rs
+++ b/src/indicators/volume.rs
@@ -768,6 +768,81 @@ impl Indicator<Candle, f64> for MoneyFlowIndex {
     }
 }
 
+/// Volume Weighted Average Price (VWAP) indicator.
+///
+/// Computes a cumulative `Σ(TP * volume) / Σ(volume)` where the typical price
+/// is `TP = (high + low + close) / 3`.
+///
+/// VWAP is **session-based** in real trading — every new session resets the
+/// accumulators to zero. This implementation exposes [`VolumeWeightedAveragePrice::reset`]
+/// (via the [`Indicator`] trait) for that purpose; if you build your own
+/// session boundaries (daily candles, opening bell, etc.), call `reset()`
+/// at the start of each session.
+///
+/// # Example
+/// ```no_run
+/// use rsta::indicators::volume::VolumeWeightedAveragePrice;
+/// use rsta::indicators::{Indicator, Candle};
+///
+/// let mut vwap = VolumeWeightedAveragePrice::new();
+/// let candles: Vec<Candle> = (0..20).map(|i| Candle {
+///     timestamp: i, open: i as f64, high: i as f64 + 1.0,
+///     low: i as f64 - 1.0, close: i as f64, volume: 1000.0 + i as f64,
+/// }).collect();
+/// let values = vwap.calculate(&candles).unwrap();
+/// assert_eq!(values.len(), candles.len());
+/// ```
+#[derive(Debug, Default)]
+pub struct VolumeWeightedAveragePrice {
+    cumulative_tp_volume: f64,
+    cumulative_volume: f64,
+}
+
+impl VolumeWeightedAveragePrice {
+    /// Create a new VWAP indicator with empty session accumulators.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Indicator<Candle, f64> for VolumeWeightedAveragePrice {
+    fn calculate(&mut self, data: &[Candle]) -> Result<Vec<f64>, IndicatorError> {
+        if data.is_empty() {
+            return Err(IndicatorError::InsufficientData(
+                "VWAP requires at least one candle".to_string(),
+            ));
+        }
+        self.reset();
+        let mut out = Vec::with_capacity(data.len());
+        for c in data {
+            if let Some(v) = self.next(*c)? {
+                out.push(v);
+            }
+        }
+        Ok(out)
+    }
+
+    fn next(&mut self, value: Candle) -> Result<Option<f64>, IndicatorError> {
+        let tp = (value.high + value.low + value.close) / 3.0;
+        self.cumulative_tp_volume += tp * value.volume;
+        self.cumulative_volume += value.volume;
+        if self.cumulative_volume == 0.0 {
+            // Pathological zero-volume input: return TP itself rather than NaN.
+            return Ok(Some(tp));
+        }
+        Ok(Some(self.cumulative_tp_volume / self.cumulative_volume))
+    }
+
+    fn reset(&mut self) {
+        self.cumulative_tp_volume = 0.0;
+        self.cumulative_volume = 0.0;
+    }
+
+    fn name(&self) -> &'static str {
+        "VWAP"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2580,5 +2655,74 @@ mod tests {
             .filter_map(|c| stream.next(*c).unwrap())
             .collect();
         assert_eq!(batch_out, stream_out);
+    }
+
+    #[test]
+    fn test_vwap_first_value_equals_tp() {
+        let mut vwap = VolumeWeightedAveragePrice::new();
+        let c = Candle {
+            timestamp: 0,
+            open: 10.0,
+            high: 12.0,
+            low: 8.0,
+            close: 10.0,
+            volume: 1000.0,
+        };
+        // TP = 10.0; volume cancels in (TP*V)/V = TP.
+        assert_eq!(vwap.next(c).unwrap(), Some(10.0));
+    }
+
+    #[test]
+    fn test_vwap_weighted_average() {
+        let mut vwap = VolumeWeightedAveragePrice::new();
+        let candles = [
+            // TP = 10, vol 100 → contributes 1000 / 100
+            Candle {
+                timestamp: 0,
+                open: 9.0,
+                high: 11.0,
+                low: 9.0,
+                close: 10.0,
+                volume: 100.0,
+            },
+            // TP = 20, vol 300 → contributes 6000 / 300
+            Candle {
+                timestamp: 1,
+                open: 19.0,
+                high: 21.0,
+                low: 19.0,
+                close: 20.0,
+                volume: 300.0,
+            },
+        ];
+        let out = vwap.calculate(&candles).unwrap();
+        assert_eq!(out[0], 10.0);
+        // Weighted average: (10*100 + 20*300) / (100 + 300) = 7000/400 = 17.5
+        assert!((out[1] - 17.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_vwap_reset_starts_new_session() {
+        let mut vwap = VolumeWeightedAveragePrice::new();
+        let early = [Candle {
+            timestamp: 0,
+            open: 100.0,
+            high: 100.0,
+            low: 100.0,
+            close: 100.0,
+            volume: 1.0,
+        }];
+        vwap.calculate(&early).unwrap();
+        vwap.reset();
+        // After reset, the first value of the new session = its own TP.
+        let new = Candle {
+            timestamp: 1,
+            open: 50.0,
+            high: 50.0,
+            low: 50.0,
+            close: 50.0,
+            volume: 1.0,
+        };
+        assert_eq!(vwap.next(new).unwrap(), Some(50.0));
     }
 } // Close the test module


### PR DESCRIPTION
## Summary

PR #8 — VWAP. Stacked sur #15.

- `VolumeWeightedAveragePrice` (alias `Vwap`) — cumulatif Σ(TP·V)/Σ(V).
- Reset à appeler à chaque nouvelle session.
- Cas pathologique volume == 0 : émet TP plutôt que NaN.

## Test plan

- [x] 122 unit + 29 doctests + 3 golden, tous verts
- [x] clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)