### PR TITLE
feat(candle): add Heikin-Ashi transformation

### DIFF
--- a/src/indicators/candle.rs
+++ b/src/indicators/candle.rs
@@ -106,6 +106,71 @@ impl PriceDataAccessor<Candle> for Candle {
     }
 }
 
+/// Convert a series of regular OHLC candles into Heikin-Ashi form.
+///
+/// Heikin-Ashi (HA) candles smooth out noise by averaging the price action
+/// across two consecutive bars. They are not an indicator in the streaming
+/// sense — they are a transformation of the input series — but they are
+/// commonly used as a *feed* for other indicators, so the function lives
+/// here next to [`Candle`] itself.
+///
+/// Definition:
+/// - `HA_close = (O + H + L + C) / 4`
+/// - `HA_open  = (HA_open[prev] + HA_close[prev]) / 2`
+///   (seeded with `(O[0] + C[0]) / 2` for the first bar)
+/// - `HA_high  = max(H, HA_open, HA_close)`
+/// - `HA_low   = min(L, HA_open, HA_close)`
+/// - volume and timestamp are forwarded from the source candle.
+///
+/// Returns an empty `Vec` if `candles` is empty.
+///
+/// # Example
+/// ```
+/// use rsta::indicators::candle::{heikin_ashi, Candle};
+///
+/// let candles = vec![
+///     Candle { timestamp: 0, open: 10.0, high: 11.0, low: 9.0, close: 10.5, volume: 1.0 },
+///     Candle { timestamp: 1, open: 10.5, high: 12.0, low: 10.0, close: 11.5, volume: 1.0 },
+/// ];
+/// let ha = heikin_ashi(&candles);
+/// assert_eq!(ha.len(), 2);
+/// // First HA close = (10 + 11 + 9 + 10.5) / 4 = 10.125
+/// assert!((ha[0].close - 10.125).abs() < 1e-12);
+/// // First HA open seeded as (10 + 10.5) / 2 = 10.25
+/// assert!((ha[0].open - 10.25).abs() < 1e-12);
+/// ```
+pub fn heikin_ashi(candles: &[Candle]) -> Vec<Candle> {
+    if candles.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(candles.len());
+    let first = &candles[0];
+    let ha_close_0 = (first.open + first.high + first.low + first.close) / 4.0;
+    let ha_open_0 = (first.open + first.close) / 2.0;
+    out.push(Candle {
+        timestamp: first.timestamp,
+        open: ha_open_0,
+        high: first.high.max(ha_open_0).max(ha_close_0),
+        low: first.low.min(ha_open_0).min(ha_close_0),
+        close: ha_close_0,
+        volume: first.volume,
+    });
+    for c in &candles[1..] {
+        let prev = out.last().unwrap();
+        let ha_close = (c.open + c.high + c.low + c.close) / 4.0;
+        let ha_open = (prev.open + prev.close) / 2.0;
+        out.push(Candle {
+            timestamp: c.timestamp,
+            open: ha_open,
+            high: c.high.max(ha_open).max(ha_close),
+            low: c.low.min(ha_open).min(ha_close),
+            close: ha_close,
+            volume: c.volume,
+        });
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -149,6 +214,59 @@ mod tests {
         assert_eq!(candle.get_low(&candle), 98.0);
         assert_eq!(candle.get_close(&candle), 103.0);
         assert_eq!(candle.get_volume(&candle), 1000.0);
+    }
+
+    #[test]
+    fn test_heikin_ashi_empty() {
+        let out = heikin_ashi(&[]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_heikin_ashi_first_bar_seeded() {
+        let candles = [Candle {
+            timestamp: 0,
+            open: 10.0,
+            high: 11.0,
+            low: 9.0,
+            close: 10.5,
+            volume: 1.0,
+        }];
+        let ha = heikin_ashi(&candles);
+        // HA_close = (10 + 11 + 9 + 10.5) / 4 = 10.125
+        assert!((ha[0].close - 10.125).abs() < 1e-12);
+        // HA_open  = (10 + 10.5) / 2 = 10.25
+        assert!((ha[0].open - 10.25).abs() < 1e-12);
+        assert_eq!(ha[0].high, 11.0); // max(11, 10.25, 10.125)
+        assert_eq!(ha[0].low, 9.0); // min(9, 10.25, 10.125)
+        assert_eq!(ha[0].volume, 1.0);
+    }
+
+    #[test]
+    fn test_heikin_ashi_recurrence_uses_prev_ha() {
+        let candles = [
+            Candle {
+                timestamp: 0,
+                open: 10.0,
+                high: 11.0,
+                low: 9.0,
+                close: 10.5,
+                volume: 1.0,
+            },
+            Candle {
+                timestamp: 1,
+                open: 10.5,
+                high: 12.0,
+                low: 10.0,
+                close: 11.5,
+                volume: 1.0,
+            },
+        ];
+        let ha = heikin_ashi(&candles);
+        // HA[1].open = (HA[0].open + HA[0].close) / 2 = (10.25 + 10.125) / 2 = 10.1875
+        assert!((ha[1].open - 10.1875).abs() < 1e-12);
+        // HA[1].close = (10.5 + 12 + 10 + 11.5) / 4 = 11.0
+        assert!((ha[1].close - 11.0).abs() < 1e-12);
     }
 
     #[test]

--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -91,7 +91,7 @@ pub mod volatility;
 pub mod volume;
 
 // Re-export core traits and types
-pub use self::candle::Candle;
+pub use self::candle::{heikin_ashi, Candle};
 pub use self::error::IndicatorError;
 pub use self::traits::{Indicator, PriceDataAccessor};
 


### PR DESCRIPTION
## Summary

PR #10 — Heikin-Ashi. Stacked sur #17.

- `heikin_ashi(&[Candle]) -> Vec<Candle>` : transformation exposée à côté de `Candle`. Pas un Indicator (pas de streaming), c'est une transformation utilisable comme feed pour les autres indicateurs.
- Re-exporté depuis `rsta::indicators`.

## Test plan

- [x] 130 unit + 31 doctests + 3 golden, tous verts
- [x] clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)