### PR TITLE
feat: examples (3) + criterion benches (2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +64,98 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csv"
@@ -60,6 +179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +193,43 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -191,6 +353,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,10 +444,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rsta"
 version = "0.0.3"
 dependencies = [
  "chrono",
+ "criterion",
  "csv",
  "ndarray",
  "num-traits",
@@ -295,6 +499,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -325,6 +538,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -396,6 +622,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +642,16 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -424,21 +670,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.24"
+name = "winapi-util"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,18 @@ statrs = "0.16"
 csv = { version = "1.3", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
+
+[dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+
+[[example]]
+name = "csv_to_indicators"
+required-features = ["csv"]
+
+[[bench]]
+name = "indicators"
+harness = false
+
+[[bench]]
+name = "backtest"
+harness = false

--- a/benches/backtest.rs
+++ b/benches/backtest.rs
@@ -1,0 +1,132 @@
+//! End-to-end backtest microbenchmark: SMA-crossover strategy on the bundled
+//! BTC daily dataset, plus a synthetic 1M-bar run that stresses the engine.
+//!
+//! Run with:
+//! ```text
+//! cargo bench --bench backtest
+//! ```
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use rsta::backtest::{Action, BacktestConfig, Backtester, Context, Quantity, Strategy};
+use rsta::indicators::trend::Sma;
+use rsta::indicators::{Candle, Indicator};
+use rsta::signals::{CrossDown, CrossUp, Signal, SignalEvent};
+
+fn data_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/btc_usd_daily.csv")
+}
+
+fn load_btc() -> Vec<Candle> {
+    let file = File::open(data_path()).expect("open btc daily");
+    let mut out = Vec::new();
+    for line in BufReader::new(file).lines() {
+        let line = line.unwrap();
+        if line.is_empty() {
+            continue;
+        }
+        let mut cols = line.split(',');
+        let ts: u64 = cols.next().unwrap().parse().unwrap();
+        let o: f64 = cols.next().unwrap().parse().unwrap();
+        let h: f64 = cols.next().unwrap().parse().unwrap();
+        let l: f64 = cols.next().unwrap().parse().unwrap();
+        let c: f64 = cols.next().unwrap().parse().unwrap();
+        let v: f64 = cols.next().unwrap().parse().unwrap();
+        out.push(Candle {
+            timestamp: ts,
+            open: o,
+            high: h,
+            low: l,
+            close: c,
+            volume: v,
+        });
+    }
+    out
+}
+
+fn synthetic_candles(n: usize) -> Vec<Candle> {
+    (0..n)
+        .map(|i| {
+            let t = i as f64;
+            let close = 100.0 + (t * 0.01).sin() * 20.0 + t * 0.001;
+            Candle {
+                timestamp: i as u64,
+                open: close - 0.25,
+                high: close + 0.5,
+                low: close - 0.5,
+                close,
+                volume: 1_000.0,
+            }
+        })
+        .collect()
+}
+
+struct SmaCrossover {
+    fast: Sma,
+    slow: Sma,
+    cross_up: CrossUp,
+    cross_down: CrossDown,
+}
+
+impl SmaCrossover {
+    fn new(fast_period: usize, slow_period: usize) -> Self {
+        Self {
+            fast: Sma::new(fast_period).unwrap(),
+            slow: Sma::new(slow_period).unwrap(),
+            cross_up: CrossUp::new(),
+            cross_down: CrossDown::new(),
+        }
+    }
+}
+
+impl Strategy for SmaCrossover {
+    fn on_candle(&mut self, candle: &Candle, _ctx: &Context) -> Action {
+        let f = <Sma as Indicator<f64, f64>>::next(&mut self.fast, candle.close).unwrap();
+        let s = <Sma as Indicator<f64, f64>>::next(&mut self.slow, candle.close).unwrap();
+        let (Some(f), Some(s)) = (f, s) else {
+            return Action::Hold;
+        };
+        let up = self.cross_up.next((f, s));
+        let down = self.cross_down.next((f, s));
+        match (up, down) {
+            (Some(SignalEvent::Long), _) => Action::EnterLong(Quantity::AllCash),
+            (_, Some(SignalEvent::Short)) => Action::Exit,
+            _ => Action::Hold,
+        }
+    }
+}
+
+fn bench_btc_daily(c: &mut Criterion) {
+    let candles = load_btc();
+    let bt = Backtester::new(BacktestConfig::default());
+    let mut group = c.benchmark_group("backtest_btc_daily");
+    group.throughput(Throughput::Elements(candles.len() as u64));
+    group.bench_function("sma_20_50_crossover", |b| {
+        b.iter(|| {
+            let mut strat = SmaCrossover::new(20, 50);
+            black_box(bt.run(&candles, &mut strat));
+        })
+    });
+    group.finish();
+}
+
+fn bench_synthetic_1m(c: &mut Criterion) {
+    let candles = synthetic_candles(1_000_000);
+    let bt = Backtester::new(BacktestConfig::default());
+    let mut group = c.benchmark_group("backtest_synthetic_1m");
+    group.sample_size(10); // bigger inputs → fewer samples
+    group.throughput(Throughput::Elements(candles.len() as u64));
+    group.bench_function("sma_20_50_crossover", |b| {
+        b.iter(|| {
+            let mut strat = SmaCrossover::new(20, 50);
+            black_box(bt.run(&candles, &mut strat));
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_btc_daily, bench_synthetic_1m);
+criterion_main!(benches);

--- a/benches/indicators.rs
+++ b/benches/indicators.rs
@@ -1,0 +1,130 @@
+//! Microbenchmarks for individual indicators on a 100k-bar synthetic
+//! series. Reports throughput as bars/second.
+//!
+//! Run with:
+//! ```text
+//! cargo bench --bench indicators
+//! ```
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use rsta::indicators::momentum::{Cci, Rsi, StochasticOscillator};
+use rsta::indicators::trend::{Adx, Ema, Macd, Sma};
+use rsta::indicators::volatility::{Atr, BollingerBands};
+use rsta::indicators::volume::{Mfi, Obv};
+use rsta::indicators::{Candle, Indicator};
+
+const N: usize = 100_000;
+
+fn synthetic_closes(n: usize) -> Vec<f64> {
+    (0..n)
+        .map(|i| {
+            let t = i as f64;
+            // Smooth wave + linear drift — gives the indicators something
+            // non-trivial to chew on without dragging in `rand`.
+            100.0 + (t * 0.01).sin() * 20.0 + t * 0.001
+        })
+        .collect()
+}
+
+fn synthetic_candles(n: usize) -> Vec<Candle> {
+    let closes = synthetic_closes(n);
+    closes
+        .iter()
+        .enumerate()
+        .map(|(i, &c)| Candle {
+            timestamp: i as u64,
+            open: c - 0.25,
+            high: c + 0.5,
+            low: c - 0.5,
+            close: c,
+            volume: 1_000.0 + (i as f64).cos() * 100.0,
+        })
+        .collect()
+}
+
+fn close_indicators(c: &mut Criterion) {
+    let closes = synthetic_closes(N);
+    let mut group = c.benchmark_group("close_indicators");
+    group.throughput(Throughput::Elements(N as u64));
+
+    group.bench_function("sma_20", |b| {
+        b.iter(|| {
+            let mut sma = Sma::new(20).unwrap();
+            black_box(<Sma as Indicator<f64, f64>>::calculate(&mut sma, &closes).unwrap())
+        })
+    });
+    group.bench_function("ema_20", |b| {
+        b.iter(|| {
+            let mut ema = Ema::new(20).unwrap();
+            black_box(<Ema as Indicator<f64, f64>>::calculate(&mut ema, &closes).unwrap())
+        })
+    });
+    group.bench_function("rsi_14", |b| {
+        b.iter(|| {
+            let mut rsi = Rsi::new(14).unwrap();
+            black_box(rsi.calculate(&closes).unwrap())
+        })
+    });
+    group.bench_function("bb_20_2", |b| {
+        b.iter(|| {
+            let mut bb = BollingerBands::new(20, 2.0).unwrap();
+            black_box(bb.calculate(&closes).unwrap())
+        })
+    });
+    group.bench_function("macd_12_26_9", |b| {
+        b.iter(|| {
+            let mut macd = Macd::new(12, 26, 9).unwrap();
+            black_box(macd.calculate(&closes).unwrap())
+        })
+    });
+    group.bench_function("cci_20", |b| {
+        b.iter(|| {
+            // Cci needs candles; reuse the synthetic dataset.
+            let candles = synthetic_candles(N);
+            let mut cci = Cci::new(20).unwrap();
+            black_box(cci.calculate(&candles).unwrap())
+        })
+    });
+    group.finish();
+}
+
+fn candle_indicators(c: &mut Criterion) {
+    let candles = synthetic_candles(N);
+    let mut group = c.benchmark_group("candle_indicators");
+    group.throughput(Throughput::Elements(N as u64));
+
+    group.bench_function("atr_14", |b| {
+        b.iter(|| {
+            let mut atr = Atr::new(14).unwrap();
+            black_box(atr.calculate(&candles).unwrap())
+        })
+    });
+    group.bench_function("obv", |b| {
+        b.iter(|| {
+            let mut obv = Obv::new();
+            black_box(obv.calculate(&candles).unwrap())
+        })
+    });
+    group.bench_function("mfi_14", |b| {
+        b.iter(|| {
+            let mut mfi = Mfi::new(14).unwrap();
+            black_box(mfi.calculate(&candles).unwrap())
+        })
+    });
+    group.bench_function("adx_14", |b| {
+        b.iter(|| {
+            let mut adx = Adx::new(14).unwrap();
+            black_box(adx.calculate(&candles).unwrap())
+        })
+    });
+    group.bench_function("stoch_14_3", |b| {
+        b.iter(|| {
+            let mut s = StochasticOscillator::new(14, 3).unwrap();
+            black_box(s.calculate(&candles).unwrap())
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, close_indicators, candle_indicators);
+criterion_main!(benches);

--- a/examples/csv_to_indicators.rs
+++ b/examples/csv_to_indicators.rs
@@ -1,0 +1,59 @@
+//! Load OHLCV from a CSV, attach a handful of indicators, export an
+//! augmented CSV with one column per indicator.
+//!
+//! Run with the `csv` feature enabled:
+//! ```text
+//! cargo run --release --features csv --example csv_to_indicators -- input.csv output.csv
+//! ```
+//!
+//! The input CSV must follow the default header schema
+//! (`Date,Open,High,Low,Close,Volume`) — see the `rsta::csv::CsvConfig`
+//! documentation if your data uses different column names or order.
+
+use std::env;
+use std::process::ExitCode;
+
+use rsta::csv::CsvFormatter;
+use rsta::indicators::momentum::Rsi;
+use rsta::indicators::trend::{Ema, Sma};
+use rsta::indicators::volatility::Atr;
+use rsta::indicators::volume::Obv;
+
+fn usage() -> ExitCode {
+    eprintln!("usage: csv_to_indicators <input.csv> <output.csv>");
+    ExitCode::from(2)
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+    let (input, output) = match args.as_slice() {
+        [_, input, output] => (input.clone(), output.clone()),
+        _ => return usage(),
+    };
+
+    let mut formatter = CsvFormatter::new();
+    if let Err(e) = formatter.load_from_file(&input) {
+        eprintln!("failed to load {input}: {e}");
+        return ExitCode::from(1);
+    }
+    println!("loaded {} rows from {input}", formatter.data().len());
+
+    // Period choice depends on the input length — a 30-row CSV cannot
+    // produce SMA(50). The values below are deliberately small so this
+    // example works on the bundled `tests/data/sample_ohlcv.csv` (30 rows);
+    // bump them to 20/50/200 on real, multi-year datasets.
+    formatter
+        .add_close_indicator("SMA5", Box::new(Sma::new(5).unwrap()))
+        .add_close_indicator("SMA10", Box::new(Sma::new(10).unwrap()))
+        .add_close_indicator("EMA5", Box::new(Ema::new(5).unwrap()))
+        .add_close_indicator("RSI7", Box::new(Rsi::new(7).unwrap()))
+        .add_candle_indicator("ATR7", Box::new(Atr::new(7).unwrap()))
+        .add_candle_indicator("OBV", Box::new(Obv::new()));
+
+    if let Err(e) = formatter.calculate_and_export(&output) {
+        eprintln!("failed to compute/export: {e}");
+        return ExitCode::from(1);
+    }
+    println!("wrote enriched CSV to {output}");
+    ExitCode::SUCCESS
+}

--- a/examples/realtime_streaming.rs
+++ b/examples/realtime_streaming.rs
@@ -1,0 +1,67 @@
+//! Streaming indicator usage: feed bars one at a time via `next()` rather
+//! than batch-computing with `calculate()`. This is what you'd do when
+//! plugging rsta into a live data feed.
+//!
+//! Run with:
+//! ```text
+//! cargo run --release --example realtime_streaming
+//! ```
+
+use rsta::indicators::momentum::Rsi;
+use rsta::indicators::trend::{Ema, Sma};
+use rsta::indicators::Indicator;
+use rsta::signals::{Signal, SignalEvent, ThresholdAbove, ThresholdBelow};
+
+fn main() {
+    // Synthetic price stream: a random-walkish sequence anchored around 100.
+    // Real systems would pipe in from a websocket or a tick queue; the
+    // contract is the same — feed prices one at a time, react to emissions.
+    let mut price = 100.0_f64;
+    let prices: Vec<f64> = (0..200)
+        .map(|i| {
+            // Pseudo-random walk: deterministic, no rand dependency.
+            let bump = ((i as f64 * 13.0).sin() + (i as f64 * 0.31).cos()) * 1.5;
+            price = (price + bump).max(1.0);
+            price
+        })
+        .collect();
+
+    let mut sma = Sma::new(14).unwrap();
+    let mut ema = Ema::new(14).unwrap();
+    let mut rsi = Rsi::new(14).unwrap();
+    let mut overbought = ThresholdAbove::new(70.0);
+    let mut oversold = ThresholdBelow::new(30.0);
+
+    println!(
+        "{:>4}  {:>7}  {:>7}  {:>7}  {:>7}  signal",
+        "bar", "price", "sma14", "ema14", "rsi14"
+    );
+
+    for (i, &p) in prices.iter().enumerate() {
+        let sma_v = <Sma as Indicator<f64, f64>>::next(&mut sma, p).unwrap();
+        let ema_v = <Ema as Indicator<f64, f64>>::next(&mut ema, p).unwrap();
+        let rsi_v = rsi.next(p).unwrap();
+
+        let signal = rsi_v.and_then(|r| {
+            // Threshold signals only fire on a transition; they share the
+            // RSI value as input.
+            let up = overbought.next(r);
+            let down = oversold.next(r);
+            match (up, down) {
+                (Some(SignalEvent::Long), _) => Some("RSI > 70 → overbought"),
+                (_, Some(SignalEvent::Short)) => Some("RSI < 30 → oversold"),
+                _ => None,
+            }
+        });
+
+        // Print only bars where we have all three indicators — keeps the
+        // output to the interesting region.
+        if let (Some(s), Some(e), Some(r)) = (sma_v, ema_v, rsi_v) {
+            print!("{:>4}  {:>7.2}  {:>7.2}  {:>7.2}  {:>7.2}  ", i, p, s, e, r);
+            match signal {
+                Some(msg) => println!("{msg}"),
+                None => println!(),
+            }
+        }
+    }
+}

--- a/examples/sma_crossover_backtest.rs
+++ b/examples/sma_crossover_backtest.rs
@@ -1,0 +1,148 @@
+//! End-to-end demo: load the bundled BTC daily dataset, run an SMA(20)
+//! over SMA(50) crossover strategy through the backtest engine, and print
+//! the resulting performance metrics.
+//!
+//! Run with:
+//! ```text
+//! cargo run --release --example sma_crossover_backtest
+//! ```
+//!
+//! The strategy enters long when the fast SMA crosses above the slow SMA
+//! and exits when it crosses below. No shorts, no pyramiding — the simplest
+//! crossover system there is. Useful as a baseline to validate that the
+//! whole stack (indicators → signals → backtest → metrics) hangs together.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use rsta::backtest::{Action, BacktestConfig, Backtester, Context, Quantity, Strategy};
+use rsta::indicators::trend::Sma;
+use rsta::indicators::{Candle, Indicator};
+use rsta::signals::{CrossDown, CrossUp, Signal, SignalEvent};
+
+fn data_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/btc_usd_daily.csv")
+}
+
+/// Minimal Kraken-style CSV loader (no header, OHLCV + trade_count).
+fn load_btc() -> Vec<Candle> {
+    let path = data_path();
+    let file = File::open(&path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut out = Vec::new();
+    for line in BufReader::new(file).lines() {
+        let line = line.expect("read line");
+        if line.is_empty() {
+            continue;
+        }
+        let mut cols = line.split(',');
+        let ts: u64 = cols.next().unwrap().parse().unwrap();
+        let o: f64 = cols.next().unwrap().parse().unwrap();
+        let h: f64 = cols.next().unwrap().parse().unwrap();
+        let l: f64 = cols.next().unwrap().parse().unwrap();
+        let c: f64 = cols.next().unwrap().parse().unwrap();
+        let v: f64 = cols.next().unwrap().parse().unwrap();
+        out.push(Candle {
+            timestamp: ts,
+            open: o,
+            high: h,
+            low: l,
+            close: c,
+            volume: v,
+        });
+    }
+    out
+}
+
+/// SMA(fast) / SMA(slow) crossover. Long when fast crosses above slow, exit
+/// when fast crosses below.
+struct SmaCrossover {
+    fast: Sma,
+    slow: Sma,
+    cross_up: CrossUp,
+    cross_down: CrossDown,
+}
+
+impl SmaCrossover {
+    fn new(fast_period: usize, slow_period: usize) -> Self {
+        Self {
+            fast: Sma::new(fast_period).unwrap(),
+            slow: Sma::new(slow_period).unwrap(),
+            cross_up: CrossUp::new(),
+            cross_down: CrossDown::new(),
+        }
+    }
+}
+
+impl Strategy for SmaCrossover {
+    fn on_candle(&mut self, candle: &Candle, _ctx: &Context) -> Action {
+        let fast = <Sma as Indicator<f64, f64>>::next(&mut self.fast, candle.close).unwrap();
+        let slow = <Sma as Indicator<f64, f64>>::next(&mut self.slow, candle.close).unwrap();
+        let (Some(f), Some(s)) = (fast, slow) else {
+            // Still warming up — both signals still need a prior pair, so
+            // feed them whatever we have to keep their internal state in
+            // sync, but emit no action.
+            return Action::Hold;
+        };
+        // Both indicators stable: feed each signal once per bar.
+        let up = self.cross_up.next((f, s));
+        let down = self.cross_down.next((f, s));
+        match (up, down) {
+            (Some(SignalEvent::Long), _) => Action::EnterLong(Quantity::AllCash),
+            (_, Some(SignalEvent::Short)) => Action::Exit,
+            _ => Action::Hold,
+        }
+    }
+}
+
+fn print_metrics(label: &str, m: &rsta::backtest::Metrics) {
+    println!("=== {label} ===");
+    println!("  final equity   : {:>14.2}", m.final_equity);
+    println!("  total return   : {:>14.2}%", m.total_return * 100.0);
+    println!("  max drawdown   : {:>14.2}%", m.max_drawdown * 100.0);
+    println!("  sharpe         : {:>14.3}", m.sharpe);
+    println!("  trades         : {:>14}", m.trade_count);
+    println!("  win rate       : {:>14.2}%", m.win_rate * 100.0);
+    println!("  profit factor  : {:>14.3}", m.profit_factor);
+}
+
+fn main() {
+    let candles = load_btc();
+    println!(
+        "loaded {} BTC daily candles ({}..{})",
+        candles.len(),
+        candles.first().map(|c| c.timestamp).unwrap_or(0),
+        candles.last().map(|c| c.timestamp).unwrap_or(0),
+    );
+
+    let config = BacktestConfig {
+        initial_cash: 10_000.0,
+        fee_rate: 0.001, // 10 bps per leg, realistic for retail crypto
+        slippage: 0.0001,
+        ..Default::default()
+    };
+    let bt = Backtester::new(config);
+
+    // Reference: buy-and-hold for comparison.
+    struct BuyAndHold {
+        entered: bool,
+    }
+    impl Strategy for BuyAndHold {
+        fn on_candle(&mut self, _c: &Candle, _ctx: &Context) -> Action {
+            if !self.entered {
+                self.entered = true;
+                Action::EnterLong(Quantity::AllCash)
+            } else {
+                Action::Hold
+            }
+        }
+    }
+    let bh = bt.run(&candles, &mut BuyAndHold { entered: false });
+    print_metrics("buy & hold", &bh.metrics);
+    println!();
+
+    // Strategy under test.
+    let mut strat = SmaCrossover::new(20, 50);
+    let result = bt.run(&candles, &mut strat);
+    print_metrics("SMA(20) / SMA(50) crossover", &result.metrics);
+}


### PR DESCRIPTION
## Summary

Démos end-to-end + microbenches criterion. L'écosystème indicateurs/signals/backtest est désormais utilisable et benchable en une commande.

### Examples (\`examples/\`)

- **\`sma_crossover_backtest.rs\`** — pipeline complet : charge le BTC daily bundled → SMA(20)/SMA(50) → CrossUp/Down → Backtester → métriques. Compare buy-and-hold vs stratégie.
- **\`realtime_streaming.rs\`** — boucle \`next()\` sur un flux de prix synthétique avec SMA + EMA + RSI + threshold signals.
- **\`csv_to_indicators.rs\`** (gated \`csv\`) — CLI \`<in> <out>\`, attache SMA/EMA/RSI/ATR/OBV via \`CsvFormatter\`.

### Benches (\`benches/\`, criterion)

- **\`indicators.rs\`** — 11 indicateurs sur 100k bougies synthétiques.
- **\`backtest.rs\`** — SMA crossover sur le BTC bundled + stress test 1M bougies.

### Sortie type

\`\`\`
=== buy & hold ===              === SMA(20)/SMA(50) crossover ===
final equity   :     6537373    final equity   :       42067
total return   :    65273.74%   total return   :     320.67%
max drawdown   :       84.98%   max drawdown   :      70.78%
sharpe         :        0.886   sharpe         :       0.470
trades         :            0   trades         :           9
                                win rate       :      66.67%
                                profit factor  :       1.948
\`\`\`

(Sur 12 ans de BTC, le simple crossover est crushé par buy-and-hold — résultat connu.)

### Perf

\`close_indicators/sma_20\` ≈ **144µs sur 100k bars** (~690 Melem/s).

## Test plan

- [x] \`cargo build --examples --features csv\` clean
- [x] \`cargo build --benches\` clean
- [x] Chaque example tourne et produit l'output attendu
- [x] \`cargo bench --bench indicators -- close_indicators/sma_20\` reporte le throughput
- [x] 188 unit + 9 golden + 42 doctests verts
- [x] clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)